### PR TITLE
[#39] add util to synchronize scale of optimizers

### DIFF
--- a/bmtrain/__init__.py
+++ b/bmtrain/__init__.py
@@ -8,7 +8,7 @@ from .utils import print_block, print_dict, print_rank, see_memory
 from .synchronize import synchronize, sum_loss, wait_loader, gather_result
 from .checkpointing import checkpoint
 from .block_layer import CheckpointBlock, TransformerBlockList
-from .backward import optim_step
+from .backward import optim_step, synchronize_optim_scale
 from .wrapper import BMTrainModelWrapper
 
 from . import debug


### PR DESCRIPTION
Usage example: 
```python
loss = ... # calculate loss
bmt.synchronize_optimizer_scale([opt1, opt2, opt3]) # new feature
loss = opt1.loss_scale(loss) # opt1 can be replaced with opt2 or opt3 because they have the same scale now
loss.backward()
bmt.optim_step(opt1, lr1)
bmt.optim_step(opt2, lr2)
bmt.optim_step(opt3, lr3)
```