### PR TITLE
fix: missing nccl

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ if os.environ.get("GITHUB_ACTIONS", "false") == "false":
     ext_modules = [
         CUDAExtension('bmtrain.nccl._C', [
             'csrc/nccl.cpp',
-        ], include_dirs=["csrc/nccl/build/include"], extra_compile_args={}),
+        ], libraries=["nccl"], include_dirs=["csrc/nccl/build/include"], extra_compile_args={}),
         CUDAExtension('bmtrain.optim._cuda', [
             'csrc/adam_cuda.cpp',
             'csrc/cuda/adam.cu',


### PR DESCRIPTION
The first CUDAExtension is missing the `libnccl.so`, we should add `nccl` to the libraries argument. Otherwise, when import bmtrain, it will complains 
```
/site-packages/bmtrain/nccl/_C.cpython-38-x86_64-linux-gnu.so: undefined symbol: ncclBroadcast
```

As the described problem in #103 and OpenBMB/CPM-Bee#18