### PR TITLE
test_synchronize.py

### DIFF
--- a/tests/test_synchronize.py
+++ b/tests/test_synchronize.py
@@ -16,10 +16,10 @@ def test_main():
         size = i + 1  
         tensor_slice = tensor[:size, :size]
         result_slice = bmt.gather_result(tensor_slice)
-        test_slice = torch.chunk(result_slice, bmt.world_size(), dim=0)[0]
+        test_slice = torch.chunk(result_slice, bmt.world_size(), dim=0)[i]
         assert torch.allclose(tensor_slice, test_slice), f"Assertion failed for tensor_slice_{i}"
- 
-    print("All tensor slice tests passed!")
+
+print("All test passed")
 
 if __name__ == '__main__':
     bmt.init_distributed(pipe_size=1)


### PR DESCRIPTION
构建了完整的测试文件
在修改之前，如果传入的tensor是其他大tensor的切片，gather时会报错："Buffer size not aligned"
构造一个大的tensor A
构造一个小tensor B指向A的一个区间
gather_result(B)
会出现“Buffer size not aligned"
