### PR TITLE
fix adam bf16 load changed to fp16

### DIFF
--- a/bmtrain/optim/adam_offload.py
+++ b/bmtrain/optim/adam_offload.py
@@ -200,8 +200,8 @@ class AdamOffloadOptimizer(torch.optim.Optimizer):
                     state[param]["_grad_fp32"] = torch.empty(param.size(), dtype=torch.float32, pin_memory=True)   # on host
                 else:
                     # initialize placeholders
-                    state[param]["_param_fp16"] = torch.empty(param.size(), dtype=torch.float16, pin_memory=True)  # on host
-                    state[param]["_grad_fp16"] = torch.empty(param.size(), dtype=torch.float16, pin_memory=True)   # on host
+                    state[param]["_param_fp16"] = torch.empty(param.size(), dtype=param.dtype, pin_memory=True)  # on host
+                    state[param]["_grad_fp16"] = torch.empty(param.size(), dtype=param.dtype, pin_memory=True)   # on host
             else:
                 state[k] = v
 

--- a/bmtrain/store.py
+++ b/bmtrain/store.py
@@ -87,7 +87,7 @@ def async_save_to_file(state_dict, file_path):
     config['finish_save'] = True
     print("finish save state_dict to ", file_path) 
 
-def save(model : torch.nn.Module, file_name : str, non_blocking : bool=True):
+def save(model : torch.nn.Module, file_name : str, non_blocking : bool=False):
     """Saves the model to the file.
 
     Similar to torch.save, but it used for distributed modules.


### PR DESCRIPTION
## Pull Request Template

### Description
When load from bf16 AdamOffload state_dict, an empty fp16 buffer is created.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
