### PR TITLE
reduce pipe parallel memory allocation peak

### DIFF
--- a/example/pipe_train.py
+++ b/example/pipe_train.py
@@ -64,7 +64,7 @@ def main():
     optim_manager = optim.OptimManager(loss_scale=2**20)
     optim_manager.add_optimizer(optimizer, lr_scheduler)
     pipe_rank = bmt.config["topology"].pipe_rank
-    model.load_state_dict(torch.load(f"pipe_{pipe_rank}.ckpt"))
+    # model.load_state_dict(torch.load(f"pipe_{pipe_rank}.ckpt"))
     bmt.synchronize()
     avg_time_recorder = bmt.utils.AverageRecorder()
     avg_loss_recorder = bmt.utils.AverageRecorder()

--- a/example/pipe_train.py
+++ b/example/pipe_train.py
@@ -64,7 +64,7 @@ def main():
     optim_manager = optim.OptimManager(loss_scale=2**20)
     optim_manager.add_optimizer(optimizer, lr_scheduler)
     pipe_rank = bmt.config["topology"].pipe_rank
-    # model.load_state_dict(torch.load(f"pipe_{pipe_rank}.ckpt"))
+    model.load_state_dict(torch.load(f"pipe_{pipe_rank}.ckpt"))
     bmt.synchronize()
     avg_time_recorder = bmt.utils.AverageRecorder()
     avg_loss_recorder = bmt.utils.AverageRecorder()


### PR DESCRIPTION
## Pull Request Template

### Issue Reference
N/A

### Description
Previous initialization of pipe modules will allocated all num layers on every devices. It is extra memory allocation and will cause memory peak. 

Now each devices only init partition layers.

Usage update:
![image](https://github.com/OpenBMB/BMTrain/assets/31957460/889edc6f-d1b4-4c02-9bfc-bde0cd0f31a6)

llama-7b loss curve (tp2pp2):
![loss](https://github.com/OpenBMB/BMTrain/assets/31957460/42e8e4b2-2fcd-46e7-b19f-65cdc7666e51)

Reproduce training script:
```bash
#! /bin/bash
set -x
SCRIPT_HOME=$(cd $(dirname $0); pwd)

export MASTER_ADDR="localhost"
export MASTER_PORT=12345


CPM_PATH="${SCRIPT_HOME}/../../"
CKPT_PATH="${SCRIPT_HOME}/../../apps/cpm9g/config/7b"
EXP_PATH=.
MODEL_NAME="cpm9g-7b-train"

OPTS=""
OPTS+=" --model-config ${CKPT_PATH}/config.json"
# OPTS+=" --tokenizer-path ${CKPT_PATH}/../tokenizer"
OPTS+=" --vocab ${CKPT_PATH}/vocab.txt"

OPTS+=" --offload"
OPTS+=" --tp 2"
OPTS+=" --pp-size 2"
OPTS+=" --num-micro-batches 2"
OPTS+=" --max-length 1024"
OPTS+=" --vocab-parallel"
OPTS+=" --lr-decay-style noam"
OPTS+=" --weight-decay 0.1"
OPTS+=" --clip-grad 1.0"
OPTS+=" --loss-scale 1048576"
OPTS+=" --loss-scale-steps 1000000"
OPTS+=" --bf16"
# OPTS+=" --flash cuda"
OPTS+=" --save ${EXP_PATH}/checkpoints"
OPTS+=" --save-name ${MODEL_NAME}"
OPTS+=" --save-model ${EXP_PATH}/models/cpm9g-7b/"
OPTS+=" --log-dir ${EXP_PATH}/log"
OPTS+=" --tensorboard ${EXP_PATH}/log/tensorboard/"`date +"%Y%m%d%H%M%S"`
OPTS+=" --dataset ./datasets_alpaca.json"
#OPTS+=" --load ${CKPT_PATH}/pytorch_model.pt"
OPTS+=" --start-step 1"
OPTS+=" --save-iters 25000"
OPTS+=" --train-iters 1000000"
OPTS+=" --batch-size 4"
OPTS+=" --lr 5e-5"
OPTS+=" --warmup-iter 1000"
# OPTS+=" --disabled-checkpoint"

OPTS+=" $@"


CMD="torchrun --nnodes=1 --nproc_per_node=4 --rdzv_id=1 --rdzv_backend=c10d --rdzv_endpoint=${MASTER_ADDR}:${MASTER_PORT} ${CPM_PATH}/apps/llama/pretrain_cpm9g_pipe.py ${OPTS}"

echo "${CMD}"
$CMD
# nohup $CMD > incremental_train.2_4096_FA_bf16.log 2>&1 &
#$CMD 2>&1 | tee incremental_train.8_4096_FA_bf16.log 

```

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

### Checklist
- [ ] I have read the [CONTRIBUTING](../../CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

### Additional Information
Any additional information, configuration, or data that might be necessary for the review.
