### PR TITLE
bmt.Block now can accept kwargs in forward function

### DIFF
--- a/bmtrain/block_layer.py
+++ b/bmtrain/block_layer.py
@@ -311,8 +311,12 @@ class Block(torch.nn.Module):
         post_out = tuple(post_out)
         return post_out
 
-    def forward(self, *args):
+    def forward(self, *args, **kwargs):
+        signature = inspect.signature(self._module.forward)
+        bound_args = signature.bind(*args, **kwargs)
+        args = bound_args.args
         arg_list = self.pre_hook(*args)
+
 
         if self.all_input_no_grad and not self.all_param_no_grad:
             placeholder = torch.tensor([], requires_grad=torch.is_grad_enabled())

--- a/bmtrain/wrapper.py
+++ b/bmtrain/wrapper.py
@@ -15,11 +15,15 @@ def make_distributed(model: torch.nn.Module):
     for kw in list(model._buffers.keys()):
         if model._buffers[kw] is not None:
             model._buffers[kw] = model._buffers[kw].cuda()
-
+    is_module_list = isinstance(model, torch.nn.ModuleList)
+    pre_module = None
     for kw in list(model._modules.keys()):
-        if isinstance(model, torch.nn.ModuleList):
+        if is_module_list:
             if not isinstance(model._modules[kw], Block):
                 model._modules[kw] = Block(model_wrapper_dispatch(model._modules[kw]))
+                if pre_module is not None:
+                    model._modules[kw].set_pre_module(pre_module)
+                pre_module = model._modules[kw]
         else:
             model._modules[kw] = model_wrapper_dispatch(model._modules[kw])
 

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ ext_modules = [
 ]
 setup(
     name='bmtrain',
-    version='1.0.0',
+    version='1.0.1',
     author="Guoyang Zeng",
     author_email="qbjooo@qq.com",
     description="A toolkit for training big models",


### PR DESCRIPTION
## `bmt.Block` now can accept kwargs in `forward` function.

### Description
`bmt.Block` can accept any kwargs variable by using `inspect` api.  

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?
Now you can use `model = BMTrainModelWrapper(model)` to convert any huggingface models to bmtrain format.

### Checklist
- [x] I have read the [CONTRIBUTING](../../CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
